### PR TITLE
solve the overrides refund payment

### DIFF
--- a/Examples/Example-Java/app/build.gradle
+++ b/Examples/Example-Java/app/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.izettle.payments.android.java_example"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/Examples/Example-Java/app/src/main/java/com/izettle/payments/android/java_example/CardReaderActivity.java
+++ b/Examples/Example-Java/app/src/main/java/com/izettle/payments/android/java_example/CardReaderActivity.java
@@ -142,7 +142,7 @@ public class CardReaderActivity extends AppCompatActivity {
 
         @Override
         public void onSuccess(CardPaymentPayload payload) {
-            TransactionReference reference = new TransactionReference.Builder(payload.getReferenceId())
+            TransactionReference reference = new TransactionReference.Builder(UUID.randomUUID().toString())
                 .put("REFUND_EXTRA_INFO", "Started from home screen")
                 .build();
             Intent intent = new RefundsActivity.IntentBuilder(CardReaderActivity.this)

--- a/Examples/Example-Java/app/src/main/java/com/izettle/payments/android/java_example/CardReaderActivity.java
+++ b/Examples/Example-Java/app/src/main/java/com/izettle/payments/android/java_example/CardReaderActivity.java
@@ -26,6 +26,7 @@ import com.izettle.payments.android.ui.readers.CardReadersActivity;
 import com.izettle.payments.android.ui.refunds.RefundResult;
 import com.izettle.payments.android.ui.refunds.RefundsActivity;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public class CardReaderActivity extends AppCompatActivity {
@@ -52,13 +53,11 @@ public class CardReaderActivity extends AppCompatActivity {
         installmentsCheckBox = findViewById(R.id.installments_check_box);
         lastPaymentTraceId = new MutableLiveData<>();
 
-        lastPaymentTraceId.observe(this, value -> {
-            refundButton.setEnabled(value != null);
-        });
+        lastPaymentTraceId.observe(this, value -> refundButton.setEnabled(value != null));
 
-        chargeButton.setOnClickListener( v -> { onChargeClicked(); });
-        refundButton.setOnClickListener( v -> { onRefundClicked(); });
-        settingsButton.setOnClickListener( v -> { onSettingsClicked(); });
+        chargeButton.setOnClickListener( v -> onChargeClicked());
+        refundButton.setOnClickListener( v -> onRefundClicked());
+        settingsButton.setOnClickListener( v -> onSettingsClicked());
     }
 
     private final ActivityResultLauncher<Intent> paymentLauncher = registerForActivityResult(new StartActivityForResult(), result -> {
@@ -67,10 +66,10 @@ public class CardReaderActivity extends AppCompatActivity {
             if(parsed instanceof CardPaymentResult.Completed) {
                 showToast("Payment completed");
                 CardPaymentResult.Completed casted = (CardPaymentResult.Completed) parsed;
-                lastPaymentTraceId.setValue(casted.getPayload().getReference().getId());
+                lastPaymentTraceId.setValue(Objects.requireNonNull(casted.getPayload().getReference()).getId());
             }
             else if(parsed instanceof CardPaymentResult.Failed) {
-                showToast("Payment failed "+ ((CardPaymentResult.Failed) parsed).getReason().toString());
+                showToast("Payment failed "+ ((CardPaymentResult.Failed) parsed).getReason());
             }
             else if(parsed instanceof CardPaymentResult.Canceled) {
                 showToast("Payment canceled");
@@ -85,7 +84,7 @@ public class CardReaderActivity extends AppCompatActivity {
                 showToast("Refund completed");
             }
             else if(parsed instanceof RefundResult.Failed) {
-                showToast("Refund failed "+ ((RefundResult.Failed) parsed).getReason().toString());
+                showToast("Refund failed "+ ((RefundResult.Failed) parsed).getReason());
             }
             else if(parsed instanceof RefundResult.Canceled) {
                 showToast("Refund canceled");

--- a/Examples/Example-Java/app/src/main/java/com/izettle/payments/android/java_example/MainActivity.java
+++ b/Examples/Example-Java/app/src/main/java/com/izettle/payments/android/java_example/MainActivity.java
@@ -33,17 +33,13 @@ public class MainActivity extends AppCompatActivity {
         openCardReaderButton = findViewById(R.id.open_card_reader_btn);
         openPayPalQrcButton = findViewById(R.id.open_paypal_btn);
 
-        toLiveData(IZettleSDK.Instance.getUser().getState()).observe(this, state -> {
-            onAuthStateChanged(state instanceof User.AuthState.LoggedIn);
-        });
+        toLiveData(IZettleSDK.Instance.getUser().getState()).observe(this, state ->
+                onAuthStateChanged(state instanceof User.AuthState.LoggedIn));
 
-        loginButton.setOnClickListener( v -> {
-            IZettleSDK.Instance.getUser().login(this, Color.WHITE);
-        });
+        loginButton.setOnClickListener( v ->
+                IZettleSDK.Instance.getUser().login(this, Color.WHITE));
 
-        logoutButton.setOnClickListener( v -> {
-            IZettleSDK.Instance.getUser().logout();
-        });
+        logoutButton.setOnClickListener( v -> IZettleSDK.Instance.getUser().logout());
 
         openCardReaderButton.setOnClickListener( v -> {
             Intent intent = new Intent(this, CardReaderActivity.class);

--- a/Examples/Example-Java/app/src/main/java/com/izettle/payments/android/java_example/PayPalQrcActivity.java
+++ b/Examples/Example-Java/app/src/main/java/com/izettle/payments/android/java_example/PayPalQrcActivity.java
@@ -47,9 +47,9 @@ public class PayPalQrcActivity extends AppCompatActivity {
         refundAmountEditText = findViewById(R.id.refund_amount_input);
         lastPaymentTraceId = new MutableLiveData<>();
 
-        chargeButton.setOnClickListener( v -> { onChargeClicked(); } );
-        settingsButton.setOnClickListener( v -> { onSettingsClicked(); } );
-        refundButton.setOnClickListener( v -> { onRefundLastPayment(); } );
+        chargeButton.setOnClickListener( v -> onChargeClicked());
+        settingsButton.setOnClickListener( v -> onSettingsClicked());
+        refundButton.setOnClickListener( v -> onRefundLastPayment());
     }
 
     private final ActivityResultLauncher<Intent> paymentLauncher = registerForActivityResult(new StartActivityForResult(), result -> {
@@ -63,7 +63,7 @@ public class PayPalQrcActivity extends AppCompatActivity {
                         .append(String.valueOf(casted.getPayment().getAmount())));
             }
             else if(parsed instanceof PayPalQrcPaymentResult.Failed) {
-                showToast("Payment failed " + ((PayPalQrcPaymentResult.Failed) parsed).getReason().toString());
+                showToast("Payment failed " + ((PayPalQrcPaymentResult.Failed) parsed).getReason());
             }
             else if(parsed instanceof PayPalQrcPaymentResult.Canceled) {
                 showToast("Payment canceled");
@@ -78,7 +78,7 @@ public class PayPalQrcActivity extends AppCompatActivity {
                 showToast("Refund completed");
             }
             else if(parsed instanceof PayPalQrcRefundResult.Failed) {
-                showToast("Refund failed "+ ((PayPalQrcRefundResult.Failed) parsed).getReason().toString());
+                showToast("Refund failed "+ ((PayPalQrcRefundResult.Failed) parsed).getReason());
             }
             else if(parsed instanceof PayPalQrcRefundResult.Canceled) {
                 showToast("Refund canceled");

--- a/Examples/Example-Java/app/src/main/res/layout/activity_paypal_qrc.xml
+++ b/Examples/Example-Java/app/src/main/res/layout/activity_paypal_qrc.xml
@@ -63,7 +63,7 @@
 
             <CheckBox
                 android:id="@+id/venmo_check_box"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:layout_weight="1"

--- a/Examples/Example-Java/build.gradle
+++ b/Examples/Example-Java/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Examples/Example-Java/gradle/wrapper/gradle-wrapper.properties
+++ b/Examples/Example-Java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 09 11:37:01 CEST 2020
+#Mon Jun 27 15:23:40 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/Examples/Example-Kotlin/app/build.gradle
+++ b/Examples/Example-Kotlin/app/build.gradle
@@ -1,15 +1,13 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.izettle.payments.android.kotlin_example"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/Examples/Example-Kotlin/app/src/main/java/com/izettle/payments/android/kotlin_example/CardReaderActivity.kt
+++ b/Examples/Example-Kotlin/app/src/main/java/com/izettle/payments/android/kotlin_example/CardReaderActivity.kt
@@ -128,7 +128,7 @@ class CardReaderActivity : AppCompatActivity() {
         }
 
         override fun onSuccess(payload: CardPaymentPayload) {
-            val reference = TransactionReference.Builder(payload.referenceId)
+            val reference = TransactionReference.Builder(UUID.randomUUID().toString())
                 .put("REFUND_EXTRA_INFO", "Started from home screen")
                 .build()
             val intent = RefundsActivity.IntentBuilder(this@CardReaderActivity)

--- a/Examples/Example-Kotlin/app/src/main/java/com/izettle/payments/android/kotlin_example/CardReaderActivity.kt
+++ b/Examples/Example-Kotlin/app/src/main/java/com/izettle/payments/android/kotlin_example/CardReaderActivity.kt
@@ -6,7 +6,6 @@ import android.widget.*
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import com.izettle.payments.android.payment.TransactionReference
 import com.izettle.payments.android.payment.refunds.CardPaymentPayload
 import com.izettle.payments.android.payment.refunds.RefundsManager
@@ -42,9 +41,9 @@ class CardReaderActivity : AppCompatActivity() {
         installmentsCheckBox = findViewById(R.id.installments_check_box)
         lastPaymentTraceId = MutableLiveData()
 
-        lastPaymentTraceId.observe(this, Observer { value: String? ->
+        lastPaymentTraceId.observe(this) { value: String? ->
             refundButton.isEnabled = value != null
-        })
+        }
 
         chargeButton.setOnClickListener { onChargeClicked() }
         refundButton.setOnClickListener { onRefundClicked() }

--- a/Examples/Example-Kotlin/app/src/main/java/com/izettle/payments/android/kotlin_example/MainActivity.kt
+++ b/Examples/Example-Kotlin/app/src/main/java/com/izettle/payments/android/kotlin_example/MainActivity.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.Observer
 import com.izettle.android.commons.ext.state.toLiveData
 import com.izettle.payments.android.sdk.IZettleSDK
 import com.izettle.payments.android.sdk.User.AuthState.LoggedIn
@@ -30,9 +29,9 @@ class MainActivity : AppCompatActivity() {
         openCardReaderButton = findViewById(R.id.open_card_reader_btn)
         openPayPalQrcButton = findViewById(R.id.open_paypal_btn)
 
-        IZettleSDK.user.state.toLiveData().observe(this, Observer { state ->
+        IZettleSDK.user.state.toLiveData().observe(this) { state ->
             onAuthStateChanged(state is LoggedIn)
-        })
+        }
 
         loginButton.setOnClickListener {
             IZettleSDK.user.login(this, Color.WHITE)

--- a/Examples/Example-Kotlin/app/src/main/res/layout/activity_paypal_qrc.xml
+++ b/Examples/Example-Kotlin/app/src/main/res/layout/activity_paypal_qrc.xml
@@ -63,7 +63,7 @@
 
             <CheckBox
                 android:id="@+id/venmo_check_box"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:layout_weight="1"

--- a/Examples/Example-Kotlin/build.gradle
+++ b/Examples/Example-Kotlin/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
 
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.5.0'
 
     apply from: 'iZettleSDK.gradle'
 
@@ -11,7 +11,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/Examples/Example-Kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/Examples/Example-Kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 09 11:37:01 CEST 2020
+#Mon Jun 27 15:23:40 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
when doing partial refunds the first will work, but when asking to do the second refund with the original ID, will return the refund - and not the original payment. And you can’t refund a refund so it will fail.  this PR to solve this by creating every refund a new reference id.